### PR TITLE
fix: imageMessage

### DIFF
--- a/src/components/pageElements/CornerSubmission/Schema.mjs
+++ b/src/components/pageElements/CornerSubmission/Schema.mjs
@@ -51,7 +51,7 @@ const gridMessages = {
   datum: 'Vertical datum is a required field.',
 };
 const imageMessage =
-  'Images must be one of the following types: jpeg, jpg, png, tiff.';
+  'Images must be jpeg or png.';
 const pdfMessage = 'An existing tiesheet PDF is required.';
 
 export const metadataSchema = yup.object().shape({


### PR DESCRIPTION
Change message text to only include the acceptable file types for pdfmake, which are jpeg and png.